### PR TITLE
Support Rails 8.1, which no longer provides `ActiveSupport::Configurable`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 3.1
   Exclude:
+    - "lib/configurable_from_env/configurable.rb"
     - "tmp/**/*"
     - "vendor/**/*"
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/mattbrictson/configurable_from_env/ci.yml)](https://github.com/mattbrictson/configurable_from_env/actions/workflows/ci.yml)
 [![Code Climate maintainability](https://img.shields.io/codeclimate/maintainability/mattbrictson/configurable_from_env)](https://codeclimate.com/github/mattbrictson/configurable_from_env)
 
-The `configurable_from_env` gem allows you to define accessors that automatically populate via environment variables. It works by extending Active Support's [`config_accessor`](https://api.rubyonrails.org/classes/ActiveSupport/Configurable/ClassMethods.html#method-i-config_accessor) with a new `:from_env` option.
+The `configurable_from_env` gem allows you to define accessors that automatically populate via environment variables. It brings back Active Support's [`config_accessor`](https://github.com/rails/rails/blob/819a94934966eafb6bee6990b18372e1eb91159d/activesupport/lib/active_support/configurable.rb#L111) – which was [removed](https://github.com/rails/rails/pull/53970) in Rails 8.1 – and enhances it with a new `:from_env` option.
 
 > [!NOTE]
 > This project is experimental. Please open an issue or send me an email and let me know what you think!

--- a/lib/configurable_from_env.rb
+++ b/lib/configurable_from_env.rb
@@ -1,15 +1,15 @@
 require "active_support"
 require "active_support/concern"
-require "active_support/configurable"
 require "active_support/core_ext/enumerable"
 require "active_support/core_ext/hash/keys"
 
 module ConfigurableFromEnv
+  autoload :Configurable, "configurable_from_env/configurable"
   autoload :EnvironmentValue, "configurable_from_env/environment_value"
   autoload :VERSION, "configurable_from_env/version"
 
   extend ActiveSupport::Concern
-  include ActiveSupport::Configurable
+  include Configurable
 
   module ClassMethods
     def config_accessor(*attributes, from_env: nil, **options, &block)

--- a/lib/configurable_from_env/configurable.rb
+++ b/lib/configurable_from_env/configurable.rb
@@ -1,0 +1,181 @@
+# Copied from https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/configurable.rb
+#
+# Copyright (c) David Heinemeier Hansson
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+require "active_support"
+require "active_support/concern"
+require "active_support/ordered_options"
+
+module ConfigurableFromEnv
+  # = Active Support \Configurable
+  #
+  # Configurable provides a <tt>config</tt> method to store and retrieve
+  # configuration options as an OrderedOptions.
+  module Configurable
+    extend ActiveSupport::Concern
+
+    class Configuration < ActiveSupport::InheritableOptions
+      def compile_methods!
+        self.class.compile_methods!(keys)
+      end
+
+      # Compiles reader methods so we don't have to go through method_missing.
+      def self.compile_methods!(keys)
+        keys.reject { |m| method_defined?(m) }.each do |key|
+          class_eval <<-RUBY, __FILE__, __LINE__ + 1
+            def #{key}; _get(#{key.inspect}); end
+          RUBY
+        end
+      end
+    end
+
+    module ClassMethods
+      def config
+        @_config ||= if respond_to?(:superclass) && superclass.respond_to?(:config)
+          superclass.config.inheritable_copy
+        else
+          # create a new "anonymous" class that will host the compiled reader methods
+          Class.new(Configuration).new
+        end
+      end
+
+      def configure
+        yield config
+      end
+
+      # Allows you to add shortcut so that you don't have to refer to attribute
+      # through config. Also look at the example for config to contrast.
+      #
+      # Defines both class and instance config accessors.
+      #
+      #   class User
+      #     include ActiveSupport::Configurable
+      #     config_accessor :allowed_access
+      #   end
+      #
+      #   User.allowed_access # => nil
+      #   User.allowed_access = false
+      #   User.allowed_access # => false
+      #
+      #   user = User.new
+      #   user.allowed_access # => false
+      #   user.allowed_access = true
+      #   user.allowed_access # => true
+      #
+      #   User.allowed_access # => false
+      #
+      # The attribute name must be a valid method name in Ruby.
+      #
+      #   class User
+      #     include ActiveSupport::Configurable
+      #     config_accessor :"1_Badname"
+      #   end
+      #   # => NameError: invalid config attribute name
+      #
+      # To omit the instance writer method, pass <tt>instance_writer: false</tt>.
+      # To omit the instance reader method, pass <tt>instance_reader: false</tt>.
+      #
+      #   class User
+      #     include ActiveSupport::Configurable
+      #     config_accessor :allowed_access, instance_reader: false, instance_writer: false
+      #   end
+      #
+      #   User.allowed_access = false
+      #   User.allowed_access # => false
+      #
+      #   User.new.allowed_access = true # => NoMethodError
+      #   User.new.allowed_access        # => NoMethodError
+      #
+      # Or pass <tt>instance_accessor: false</tt>, to omit both instance methods.
+      #
+      #   class User
+      #     include ActiveSupport::Configurable
+      #     config_accessor :allowed_access, instance_accessor: false
+      #   end
+      #
+      #   User.allowed_access = false
+      #   User.allowed_access # => false
+      #
+      #   User.new.allowed_access = true # => NoMethodError
+      #   User.new.allowed_access        # => NoMethodError
+      #
+      # Also you can pass <tt>default</tt> or a block to set up the attribute with a default value.
+      #
+      #   class User
+      #     include ActiveSupport::Configurable
+      #     config_accessor :allowed_access, default: false
+      #     config_accessor :hair_colors do
+      #       [:brown, :black, :blonde, :red]
+      #     end
+      #   end
+      #
+      #   User.allowed_access # => false
+      #   User.hair_colors # => [:brown, :black, :blonde, :red]
+      def config_accessor(*names, instance_reader: true, instance_writer: true, instance_accessor: true, default: nil) # :doc:
+        names.each do |name|
+          raise NameError.new("invalid config attribute name") unless /\A[_A-Za-z]\w*\z/.match?(name)
+
+          reader, reader_line = "def #{name}; config.#{name}; end", __LINE__
+          writer, writer_line = "def #{name}=(value); config.#{name} = value; end", __LINE__
+
+          singleton_class.class_eval reader, __FILE__, reader_line
+          singleton_class.class_eval writer, __FILE__, writer_line
+
+          if instance_accessor
+            class_eval reader, __FILE__, reader_line if instance_reader
+            class_eval writer, __FILE__, writer_line if instance_writer
+          end
+
+          send("#{name}=", block_given? ? yield : default)
+        end
+      end
+      private :config_accessor
+
+      private
+        def inherited(subclass)
+          super
+          subclass.class_eval do
+            @_config = nil
+          end
+        end
+    end
+
+    # Reads and writes attributes from a configuration OrderedOptions.
+    #
+    #   require "active_support/configurable"
+    #
+    #   class User
+    #     include ActiveSupport::Configurable
+    #   end
+    #
+    #   user = User.new
+    #
+    #   user.config.allowed_access = true
+    #   user.config.level = 1
+    #
+    #   user.config.allowed_access # => true
+    #   user.config.level          # => 1
+    def config
+      @_config ||= self.class.config.inheritable_copy
+    end
+  end
+end


### PR DESCRIPTION
Starting with Rails 8.1, ActiveSupport will no longer provide `ActiveSupport::Configurable`. This PR adds support for Rails 8.1 by copying the Rails 8.0 `ActiveSupport::Configurable` code into this repo.